### PR TITLE
Update to base-4.11

### DIFF
--- a/monad-unify.cabal
+++ b/monad-unify.cabal
@@ -13,7 +13,7 @@ author: Phil Freeman
 data-dir: ""
 
 library
-    build-depends: base ==4.*,
+    build-depends: base >=4.11,
                    mtl -any,
                    unordered-containers -any
     exposed-modules: Control.Monad.Unify


### PR DESCRIPTION
* Remove deprecated Control.Monad.Error
* Add Semigroup (Substitution t) instance